### PR TITLE
Update GoogleCloudVision Key Regex

### DIFF
--- a/lib/Vis2.ahk
+++ b/lib/Vis2.ahk
@@ -1979,7 +1979,7 @@ class Vis2 {
                if FileExist("Vis2_API.txt") {
                   file := FileOpen("Vis2_API.txt", "r")
                   keys := file.Read()
-                  api_key := ((___ := RegExReplace(keys, "s)^.*?GoogleCloudVision(?:\s*)=(?:\s*)([A-Za-z0-9\-]+).*$", "$1")) != keys) ? ___ : ""
+                  api_key := ((___ := RegExReplace(keys, "s)^.*?GoogleCloudVision(?:\s*)=(?:\s*)([A-Za-z0-9_\-]+).*$", "$1")) != keys) ? ___ : ""
                   file.close()
 
                   if (api_key != "")


### PR DESCRIPTION
If there is an underscore in your API key for Google Cloud Vision the regex only matches everything before the underscore. This results in an invalid API key response. Google nowadays also allows for underscores in the API key it should be added to the regex as well. 

Very small change to make the `IdentifyImage` function work again.